### PR TITLE
Checking for window.devToolsExtension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import NotFound from './pages/NotFound';
 // create the store
 const sagaMiddleware = createSagaMiddleware();
 let middleware = applyMiddleware(routerMiddleware(browserHistory), sagaMiddleware);
-if (process.env.NODE_ENV !== 'production') {
+if (process.env.NODE_ENV !== 'production' && window.devToolsExtension) {
     middleware = compose(middleware, window.devToolsExtension && window.devToolsExtension());
 }
 const store = createStore(reducers, middleware);


### PR DESCRIPTION
This is consistent with src_users. Without this the src version fails unless dev tools are present.